### PR TITLE
Build username from outcome service URL and user ID if provided

### DIFF
--- a/tool.php
+++ b/tool.php
@@ -60,7 +60,12 @@ if ($context->valid) {
     }
 
     // We need an username without extended chars
-    $username = 'ltiprovider'.md5($context->getUserKey());
+    if (empty($context->info['user_id']) || empty($context->info['lis_outcome_service_url'])) {
+        $userid = $context->getUserKey();
+    } else {
+        $userid = $context->info['user_id'] . ':' . $context->info['lis_outcome_service_url'];
+    }
+    $username = 'ltiprovider'.md5($userid);
 
     // Check if the user exists
     $user = $DB->get_record('user', array('username' => $username));


### PR DESCRIPTION
This prevents multiple accounts from being created for the same remote user for different activities.
Because we use the shared secret as the consumer key, we end up with a couple of issues:
* a different consumer key being used for each activity by the same consumer
* the same consumer key being used by different consumers for the same activity
The multiple accounts are caused by the former, whilst the latter could cause conflicts between consumers.