### PR TITLE
LTI User creation with anonymous user security settings

### DIFF
--- a/ims-blti/blti.php
+++ b/ims-blti/blti.php
@@ -148,12 +148,12 @@ class BLTI {
     }
 
     function getUserEmail() {
-        $email = $this->info['lis_person_contact_email_primary'];
-        if ( strlen($email) > 0 ) return $email;
+        # set default email in the event privacy settings don't pass in email.
+        $email = $this->info['user_id'] . "@ltiuser.com";
+        if ( isset($this->info['lis_person_contact_email_primary']) ) $email = $this->info['lis_person_contact_email_primary']; 
         # Sakai Hack
-        $email = $this->info['lis_person_contact_emailprimary'];
-        if ( strlen($email) > 0 ) return $email;
-        return false;
+        if ( isset($this->info['lis_person_contact_emailprimary']) ) $email = $this->info['lis_person_contact_emailprimary']; 
+        return $email;
     }
 
     function getUserShortName() {

--- a/locallib.php
+++ b/locallib.php
@@ -192,8 +192,8 @@ function local_ltiprovider_enrol_user($tool, $user, $roles, $return = false) {
  */
 function local_ltiprovider_populate($user, $context, $tool) {
     global $CFG;
-    $user->firstname = isset($context->info['lis_person_name_given'])? $context->info['lis_person_name_given'] : $context->getUserEmail();
-    $user->lastname = isset($context->info['lis_person_name_family'])? $context->info['lis_person_name_family']: '';
+    $user->firstname = isset($context->info['lis_person_name_given'])? $context->info['lis_person_name_given'] : $context->info['user_id'];
+    $user->lastname = isset($context->info['lis_person_name_family'])? $context->info['lis_person_name_family']: $context->info['context_id'];
     $user->email = clean_param($context->getUserEmail(), PARAM_EMAIL);
     $user->city = (!empty($tool->city)) ? $tool->city : "";
     $user->country = (!empty($tool->country)) ? $tool->country : "";


### PR DESCRIPTION
Update blti.php and locallib.php to handle LTI user creation without email and name sent due to security settings. LTI Documentation says the name and email fields are recommended but can be left out due to security settings, so the plugin should handle user creation without email or name sent.