### PR TITLE
Using consistent method of detecting if user is instructor.

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -106,17 +106,16 @@ function local_ltiprovider_unenrol_user($tool, $user) {
  * Enrol a user in a course
  * @param  stdclass  $tool   The tool object
  * @param  stdclass  $user   The user object
- * @param  array  $roles  Roles of the current user
+ * @param  boolean  $isinstructor  Is instructor or not (learner).
  * @param  boolean $return If we should return information
  * @return mix          Boolean if $return is set to true
  */
-function local_ltiprovider_enrol_user($tool, $user, $roles, $return = false) {
+function local_ltiprovider_enrol_user($tool, $user, $isinstructor, $return = false) {
     global $DB;
 
     $course = $DB->get_record('course', array('id' => $tool->courseid), '*', MUST_EXIST);
 
     $manual = enrol_get_plugin('manual');
-    $role =(in_array('instructor', $roles))? 'Instructor' : 'Learner';
 
     $today = time();
     $today = make_timestamp(date('Y', $today), date('m', $today), date('d', $today), 0, 0, 0);
@@ -127,7 +126,7 @@ function local_ltiprovider_enrol_user($tool, $user, $roles, $return = false) {
 
     // Course role id for the Instructor or Learner
     // TODO Do something with lti system admin (urn:lti:sysrole:ims/lis/Administrator)
-    $roleid = ($role == 'Instructor')? $tool->croleinst: $tool->crolelearn;
+    $roleid = $isinstructor ? $tool->croleinst: $tool->crolelearn;
 
     if ($instances = enrol_get_instances($course->id, false)) {
         foreach ($instances as $instance) {

--- a/test/lms.php
+++ b/test/lms.php
@@ -21,7 +21,7 @@ require_once("../ims-blti/blti_util.php");
       "resource_link_title" => "Weekly Blog",
       "resource_link_description" => "A weekly blog.",
       "user_id" => "292832126",
-      "roles" => "Instructor",  // or Learner
+      "roles" => "urn:lti:role:ims/lis/Instructor",  // or urn:lti:instrole:ims/lis/Learner
       "lis_person_name_full" => 'Jane Q. Public',
       "lis_person_name_family" => 'Public',
       "lis_person_name_given" => 'Given',

--- a/tool.php
+++ b/tool.php
@@ -422,13 +422,15 @@ if ($context->valid) {
     $course = $DB->get_record('course', array('id' => $courseid), '*', MUST_EXIST);
 
     // Enrol the user in the course
-    $roles = explode(',', strtolower($context->info['roles']));
-    local_ltiprovider_enrol_user($tool, $user, $roles);
+    $isinstructor = $context->isInstructor();
+    local_ltiprovider_enrol_user($tool, $user, $isinstructor);
 
     if ($moodlecontext->contextlevel == CONTEXT_MODULE) {
+        $role = $isinstructor ? 'instructor' : 'learner';
+
         // Enrol the user in the activity
-        if (($tool->aroleinst and in_array('instructor', $roles)) or ($tool->arolelearn and in_array('learner', $roles))) {
-            $roleid = ($role == 'instructor')? $tool->aroleinst: $tool->arolelearn;
+        if (($tool->aroleinst and $isinstructor) or ($tool->arolelearn and !$isinstructor)) {
+            $roleid = $isinstructor ? $tool->aroleinst : $tool->arolelearn;
             role_assign($roleid, $user->id, $tool->contextid);
         }
     }


### PR DESCRIPTION
* Handling case in which LTI tool gives LIS URN value for Instructor (urn:lti:instrole:ims/lis/Instructor).

Testing
1. Go to the following test script on your dev instance's web browser: <Moodle URL>/local/ltiprovider/test/lms.php
2. Setup LTI provider details and provide secret and launch url and click "Recompute Launch Data". Be sure to setup instructor/teacher role in settings
3. Click "Press to Launch"
4. Verify that user got into course as instructor with roles being "urn:lti:role:ims/lis/Instructor" or "Instructor".
5. Test same procedure above, but for student and with role being "urn:lti:role:ims/lis/Learner" or "Learner".