### PR TITLE
deprecated call to get_list_of_timezones()

### DIFF
--- a/edit_form.php
+++ b/edit_form.php
@@ -145,7 +145,7 @@ class edit_form extends moodleform {
         }
         $mform->setAdvanced('country');
 
-        $choices = get_list_of_timezones();
+        $choices = core_date::get_list_of_timezones();
         $choices['99'] = get_string('serverlocaltime');
         $mform->addElement('select', 'timezone', get_string('timezone'), $choices);
         $mform->setDefault('timezone', $templateuser->timezone);


### PR DESCRIPTION
deprecated function call to get_list_of_timezones(), use static method core_date::get_list_of_timezones() instead