### PR TITLE
To avoid empty right column

### DIFF
--- a/styles.php
+++ b/styles.php
@@ -65,6 +65,9 @@ if ($tool->hideleftblocks or $SESSION->ltiprovider->hideleftblocks) {
     #mod_quiz_navblock {
      display: block !important;
     }
+    .empty-region-side-post.used-region-side-pre #region-main.span8 {
+     width: inherit;
+    }
     ';
 }
 if ($tool->hiderightblocks or $SESSION->ltiprovider->hiderightblocks) {


### PR DESCRIPTION
When setting "hide left column" is on : we get an useless empty space instead of left blocks.
This little fix allow main content to take that empty space (only in this case)