### PR TITLE
Restore course

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -444,7 +444,10 @@ function local_ltiprovider_create_tool($courseid, $contextid, $lticontext) {
 
     // Check if we need to unzip the file because the backup temp dir does not contains backup files.
     if (!file_exists($backupbasepath . "/moodle_backup.xml")) {
-        $file->extract_to_pathname(get_file_packer(), $backupbasepath);
+      //Moodle <=2.8
+      //$file->extract_to_pathname(get_file_packer(), $backupbasepath);
+      //Moodle 2.9 or later
+      $file->extract_to_pathname(get_file_packer('application/vnd.moodle.backup'), $backupbasepath);
     }
 
     $rc = new restore_controller($backupid, $newcourse->id,
@@ -728,5 +731,3 @@ function local_ltiprovider_update_user_profile_image($userid, $url) {
     }
     return "Error downloading profile image from $url";
 }
-
-

--- a/locallib.php
+++ b/locallib.php
@@ -444,9 +444,6 @@ function local_ltiprovider_create_tool($courseid, $contextid, $lticontext) {
 
     // Check if we need to unzip the file because the backup temp dir does not contains backup files.
     if (!file_exists($backupbasepath . "/moodle_backup.xml")) {
-      //Moodle <=2.8
-      //$file->extract_to_pathname(get_file_packer(), $backupbasepath);
-      //Moodle 2.9 or later
       $file->extract_to_pathname(get_file_packer('application/vnd.moodle.backup'), $backupbasepath);
     }
 


### PR DESCRIPTION
When you are using create_context and context_template custom parameters the course is not restored in moodle 2.9 or later